### PR TITLE
feat(cliversion): add exportable build/version info package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Also automatically sets up `GOMAXPROCS` and `GOMEMLIMIT`.
 | `app`        | Automatic setup observability and run daemon               |
 | `autometric` | Reflect-based OpenTelemetry metric initializer             |
 | `otelsync`   | OpenTelemetry synchronous adapter for async metrics        |
+| `cliversion` | Build/version info from `runtime/debug.BuildInfo`          |
 
 ## Environment variables
 

--- a/app/app.go
+++ b/app/app.go
@@ -105,6 +105,7 @@ func Run(f func(ctx context.Context, lg *zap.Logger, t *Telemetry) error, op ...
 				zap.String("version", info.Version),
 				zap.String("commit", info.Commit),
 				zap.String("go_version", info.GoVersion),
+				zap.Bool("modified", info.Modified),
 			)
 		} else {
 			lg.Info("Starting")

--- a/app/app.go
+++ b/app/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-faster/sdk/internal/zapencoder"
 
 	"github.com/go-faster/sdk/autologs"
+	"github.com/go-faster/sdk/cliversion"
 	"github.com/go-faster/sdk/zctx"
 )
 
@@ -98,7 +99,19 @@ func Run(f func(ctx context.Context, lg *zap.Logger, t *Telemetry) error, op ...
 	shutdownCtx, cancel := signal.NotifyContext(ctx, os.Interrupt)
 	defer cancel()
 
-	lg.Info("Starting")
+	if opts.modulePath != "" {
+		if info, ok := cliversion.GetInfo(opts.modulePath); ok {
+			lg.Info("Starting",
+				zap.String("version", info.Version),
+				zap.String("commit", info.Commit),
+				zap.String("go_version", info.GoVersion),
+			)
+		} else {
+			lg.Info("Starting")
+		}
+	} else {
+		lg.Info("Starting")
+	}
 	res, err := opts.resourceFn(ctx)
 	if err != nil {
 		panic(fmt.Sprintf("failed to get resource: %v", err))

--- a/app/option.go
+++ b/app/option.go
@@ -24,6 +24,7 @@ type options struct {
 	loggerOptions   []autologs.Option
 	resourceOptions []resource.Option
 	resourceFn      func(ctx context.Context) (*resource.Resource, error)
+	modulePath      string
 }
 
 func (o *options) modifyZapConfig(cb func(*zap.Config)) {
@@ -140,5 +141,15 @@ func WithContext(ctx context.Context) Option {
 func WithResource(fn func(ctx context.Context) (*resource.Resource, error)) Option {
 	return optionFunc(func(o *options) {
 		o.resourceFn = fn
+	})
+}
+
+// WithModulePath sets the module path used to look up build version information
+// (e.g. "github.com/go-faster/sdk"). If set, version info is logged on startup.
+//
+// See [cliversion.GetInfo].
+func WithModulePath(modulePath string) Option {
+	return optionFunc(func(o *options) {
+		o.modulePath = modulePath
 	})
 }

--- a/cliversion/cliversion.go
+++ b/cliversion/cliversion.go
@@ -1,0 +1,100 @@
+// Package cliversion provides the version of the binary.
+package cliversion
+
+import (
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+func getVersion(modulePath string, m *debug.Module) (string, bool) {
+	if m == nil || m.Path != modulePath {
+		return "", false
+	}
+	return m.Version, true
+}
+
+func getInfo(modulePath string) (info Info, _ bool) {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return info, ok
+	}
+	info.GoVersion = bi.GoVersion
+
+	var isDep bool
+	if v, ok := getVersion(modulePath, &bi.Main); ok {
+		info.Version = v
+	} else {
+		isDep = true
+		for _, m := range bi.Deps {
+			if v, ok := getVersion(modulePath, m); ok {
+				info.Version = v
+				break
+			}
+		}
+	}
+
+	if !isDep {
+		for _, s := range bi.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				info.Commit = s.Value
+			case "vcs.time":
+				if t, err := time.Parse(time.RFC3339Nano, s.Value); err == nil {
+					info.Time = t
+				}
+			}
+		}
+	}
+	return info, true
+}
+
+// Info is the build information.
+type Info struct {
+	// Version is the version of the module.
+	Version string
+	// GoVersion is the version of the Go that produced this binary.
+	GoVersion string
+
+	// Commit is the current commit hash.
+	Commit string
+	// Time is the time of the build.
+	Time time.Time
+}
+
+// GetInfo returns the build information.
+func GetInfo(modulePath string) (Info, bool) {
+	return getInfo(modulePath)
+}
+
+// String returns string representation of the build information.
+func (i Info) String() string {
+	var s strings.Builder
+	s.WriteString("version ")
+	if v := i.Version; v != "" {
+		s.WriteString(v)
+	} else {
+		s.WriteString("unknown")
+	}
+	if commit := i.Commit; commit != "" {
+		s.WriteByte('-')
+		s.WriteString(commit)
+	}
+
+	if t, v := i.Time, i.GoVersion; v != "" || !t.IsZero() {
+		s.WriteString(" (built")
+		if v != "" {
+			s.WriteString(" with ")
+			s.WriteString(v)
+		}
+		if !t.IsZero() {
+			s.WriteString(" at ")
+			s.WriteString(t.Format(time.RFC1123))
+		}
+		s.WriteByte(')')
+	}
+	const osArch = " " + runtime.GOOS + "/" + runtime.GOARCH
+	s.WriteString(osArch)
+	return s.String()
+}

--- a/cliversion/cliversion.go
+++ b/cliversion/cliversion.go
@@ -44,6 +44,8 @@ func getInfo(modulePath string) (info Info, _ bool) {
 				if t, err := time.Parse(time.RFC3339Nano, s.Value); err == nil {
 					info.Time = t
 				}
+			case "vcs.modified":
+				info.Modified = s.Value == "true"
 			}
 		}
 	}
@@ -61,6 +63,8 @@ type Info struct {
 	Commit string
 	// Time is the time of the build.
 	Time time.Time
+	// Modified reports whether the working tree had local modifications on top of Commit.
+	Modified bool
 }
 
 // GetInfo returns the build information.
@@ -79,7 +83,13 @@ func (i Info) String() string {
 	}
 	if commit := i.Commit; commit != "" {
 		s.WriteByte('-')
+		if len(commit) > 12 {
+			commit = commit[:12]
+		}
 		s.WriteString(commit)
+		if i.Modified {
+			s.WriteString("-dirty")
+		}
 	}
 
 	if t, v := i.Time, i.GoVersion; v != "" || !t.IsZero() {

--- a/cliversion/cliversion_test.go
+++ b/cliversion/cliversion_test.go
@@ -14,5 +14,15 @@ func TestGetInfo(t *testing.T) {
 }
 
 func TestInfoString(t *testing.T) {
-	require.Equal(t, "version unknown "+runtime.GOOS+"/"+runtime.GOARCH, Info{}.String())
+	osArch := runtime.GOOS + "/" + runtime.GOARCH
+	require.Equal(t, "version unknown "+osArch, Info{}.String())
+
+	info := Info{
+		Version: "v1.2.3",
+		Commit:  "abcdef0123456789",
+	}
+	require.Equal(t, "version v1.2.3-abcdef012345 "+osArch, info.String())
+
+	info.Modified = true
+	require.Equal(t, "version v1.2.3-abcdef012345-dirty "+osArch, info.String())
 }

--- a/cliversion/cliversion_test.go
+++ b/cliversion/cliversion_test.go
@@ -1,0 +1,18 @@
+package cliversion
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetInfo(t *testing.T) {
+	info, ok := GetInfo("github.com/go-faster/sdk")
+	require.True(t, ok)
+	require.NotEmpty(t, info.GoVersion)
+}
+
+func TestInfoString(t *testing.T) {
+	require.Equal(t, "version unknown "+runtime.GOOS+"/"+runtime.GOARCH, Info{}.String())
+}


### PR DESCRIPTION
## Summary
- Add `cliversion` package (ported from oteldb's `internal/cliversion`) for reading module version/commit/Go version from `runtime/debug.BuildInfo`, so other repos can depend on it directly.
- Wire it into `app.Run` via a new `WithModulePath` option, which logs version/commit/go_version on the "Starting" log line when set.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cliversion/... ./app/...`
- [x] `golangci-lint run ./cliversion/... ./app/...`