### PR TITLE
fix(app): let env resource attributes override programmatic ones

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -53,11 +53,7 @@ func Run(f func(ctx context.Context, lg *zap.Logger, t *Telemetry) error, op ...
 		resourceOptions: defaultResourceOptions(),
 	}
 	opts.resourceFn = func(ctx context.Context) (*resource.Resource, error) {
-		r, err := resource.New(ctx, opts.resourceOptions...)
-		if err != nil {
-			return nil, errors.Wrap(err, "new")
-		}
-		return resource.Merge(resource.Default(), r)
+		return newResource(ctx, opts.resourceOptions)
 	}
 	if v, err := strconv.ParseBool(os.Getenv("OTEL_ZAP_TEE")); err == nil {
 		// Override default.

--- a/app/option.go
+++ b/app/option.go
@@ -105,9 +105,12 @@ func WithTracerOptions(opts ...autotracer.Option) Option {
 	})
 }
 
-// WithResourceOptions sets the default resource options.
+// WithResourceOptions replaces the default resource options.
 //
 // Use before [WithResource] or [WithServiceName] to override default resource options.
+//
+// Note that [resource.WithFromEnv] is always applied last regardless of given options,
+// so OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES keep working.
 func WithResourceOptions(opts ...resource.Option) Option {
 	return optionFunc(func(o *options) {
 		o.resourceOptions = opts
@@ -115,6 +118,8 @@ func WithResourceOptions(opts ...resource.Option) Option {
 }
 
 // WithServiceName sets the default service name for the application.
+//
+// Overridden by OTEL_SERVICE_NAME or service.name from OTEL_RESOURCE_ATTRIBUTES.
 func WithServiceName(name string) Option {
 	return optionFunc(func(o *options) {
 		o.resourceOptions = append(o.resourceOptions, resource.WithAttributes(semconv.ServiceName(name)))
@@ -122,6 +127,8 @@ func WithServiceName(name string) Option {
 }
 
 // WithServiceNamespace sets the default service namespace for the application.
+//
+// Overridden by service.namespace from OTEL_RESOURCE_ATTRIBUTES.
 func WithServiceNamespace(namespace string) Option {
 	return optionFunc(func(o *options) {
 		o.resourceOptions = append(o.resourceOptions, resource.WithAttributes(semconv.ServiceNamespace(namespace)))

--- a/app/resource.go
+++ b/app/resource.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"slices"
 
 	"github.com/go-faster/errors"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -19,8 +20,20 @@ func defaultResourceOptions() []resource.Option {
 		resource.WithProcessExecutableName(),
 		resource.WithProcessExecutablePath(),
 		resource.WithProcessCommandArgs(),
-		resource.WithFromEnv(),
 	}
+}
+
+// newResource builds resource from given options.
+//
+// [resource.WithFromEnv] is always applied last, so OTEL_SERVICE_NAME and
+// OTEL_RESOURCE_ATTRIBUTES take precedence over attributes set programmatically.
+func newResource(ctx context.Context, opts []resource.Option) (*resource.Resource, error) {
+	opts = append(slices.Clip(opts), resource.WithFromEnv())
+	r, err := resource.New(ctx, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "new")
+	}
+	return resource.Merge(resource.Default(), r)
 }
 
 // Resource returns new resource for application.

--- a/app/resource_test.go
+++ b/app/resource_test.go
@@ -28,3 +28,71 @@ func TestDefaultResourceOptionsWithoutUser(t *testing.T) {
 		require.NotEqual(t, "process.owner", string(attr.Key))
 	}
 }
+
+func TestNewResourceEnvPrecedence(t *testing.T) {
+	newOptions := func(o ...Option) []resource.Option {
+		opts := options{resourceOptions: defaultResourceOptions()}
+		for _, opt := range o {
+			opt.apply(&opts)
+		}
+		return opts.resourceOptions
+	}
+	attributes := func(t *testing.T, res *resource.Resource) map[string]string {
+		t.Helper()
+
+		m := map[string]string{}
+		for _, attr := range res.Attributes() {
+			m[string(attr.Key)] = attr.Value.String()
+		}
+		return m
+	}
+
+	t.Run("Programmatic", func(t *testing.T) {
+		t.Setenv("OTEL_SERVICE_NAME", "")
+		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+
+		res, err := newResource(context.Background(), newOptions(
+			WithServiceName("app"),
+			WithServiceNamespace("ns"),
+		))
+		require.NoError(t, err)
+
+		attrs := attributes(t, res)
+		require.Equal(t, "app", attrs["service.name"])
+		require.Equal(t, "ns", attrs["service.namespace"])
+	})
+	t.Run("ServiceNameEnv", func(t *testing.T) {
+		t.Setenv("OTEL_SERVICE_NAME", "app-from-env")
+		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.namespace=ns-from-env")
+
+		res, err := newResource(context.Background(), newOptions(
+			WithServiceName("app"),
+			WithServiceNamespace("ns"),
+		))
+		require.NoError(t, err)
+
+		attrs := attributes(t, res)
+		require.Equal(t, "app-from-env", attrs["service.name"])
+		require.Equal(t, "ns-from-env", attrs["service.namespace"])
+	})
+	t.Run("ResourceAttributesEnv", func(t *testing.T) {
+		t.Setenv("OTEL_SERVICE_NAME", "")
+		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=app-from-env")
+
+		res, err := newResource(context.Background(), newOptions(WithServiceName("app")))
+		require.NoError(t, err)
+
+		require.Equal(t, "app-from-env", attributes(t, res)["service.name"])
+	})
+	t.Run("ResourceOptionsReplaced", func(t *testing.T) {
+		t.Setenv("OTEL_SERVICE_NAME", "app-from-env")
+
+		res, err := newResource(context.Background(), newOptions(
+			WithResourceOptions(resource.WithTelemetrySDK()),
+			WithServiceName("app"),
+		))
+		require.NoError(t, err)
+
+		require.Equal(t, "app-from-env", attributes(t, res)["service.name"])
+	})
+}

--- a/cmd/sdk-example/main.go
+++ b/cmd/sdk-example/main.go
@@ -45,12 +45,13 @@ func main() {
 		app.WithServiceNamespace("sdk"),
 
 		// Set default resource options.
+		//
+		// Note that resource.WithFromEnv() is always applied last.
 		app.WithResourceOptions(
 			resource.WithProcessRuntimeDescription(),
 			resource.WithProcessRuntimeVersion(),
 			resource.WithProcessRuntimeName(),
 			resource.WithOS(),
-			resource.WithFromEnv(),
 			resource.WithTelemetrySDK(),
 			resource.WithHost(),
 			resource.WithProcess(),


### PR DESCRIPTION
`resource.WithFromEnv()` is now applied last when building the resource, instead of being a plain entry in the default option slice.

- `WithServiceName`/`WithServiceNamespace` behave as documented defaults: `OTEL_SERVICE_NAME` and `service.name`/`service.namespace` from `OTEL_RESOURCE_ATTRIBUTES` win.
- `WithResourceOptions` no longer silently disables env-based resource attributes when it replaces the defaults.

Fixes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)