### PR TITLE
feat(auto): support exporter lists and additional exporters

### DIFF
--- a/autologs/autologs.go
+++ b/autologs/autologs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/go-faster/errors"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
@@ -16,12 +15,14 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/go-faster/sdk/internal/autoenv"
 	"github.com/go-faster/sdk/zctx"
 )
 
 const (
-	expOTLP = "otlp"
-	expNone = "none" // no-op
+	expOTLP    = "otlp"
+	expConsole = "console"
+	expNone    = autoenv.ExporterNone // no-op
 
 	protoHTTP         = "http"
 	protoHTTPProtobuf = "http/protobuf"
@@ -36,7 +37,7 @@ const (
 
 func writerByName(name string) io.Writer {
 	switch name {
-	case writerStdout:
+	case writerStdout, expConsole:
 		return os.Stdout
 	case writerStderr:
 		return os.Stderr
@@ -58,6 +59,8 @@ func nop(_ context.Context) error { return nil }
 type ShutdownFunc func(ctx context.Context) error
 
 // NewLoggerProvider initializes new [log.LoggerProvider] with the given options from environment variables.
+//
+// OTEL_LOGS_EXPORTER is a comma-separated list of exporters, all of them are used.
 func NewLoggerProvider(ctx context.Context, options ...Option) (
 	logProvider log.LoggerProvider,
 	logShutdown ShutdownFunc,
@@ -65,22 +68,41 @@ func NewLoggerProvider(ctx context.Context, options ...Option) (
 ) {
 	cfg := newConfig(options)
 	lg := zctx.From(ctx)
+
+	const envName = "OTEL_LOGS_EXPORTER"
+	exporters, err := autoenv.ParseExporters(getEnvOr(envName, expOTLP))
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "parse %s", envName)
+	}
+	if exporters[0] == expNone {
+		lg.Debug("Using no-op logs exporter")
+		return noop.NewLoggerProvider(), nop, nil
+	}
+
 	var logOptions []sdklog.LoggerProviderOption
 	if cfg.res != nil {
 		logOptions = append(logOptions, sdklog.WithResource(cfg.res))
 	}
-
-	ret := func(e sdklog.Exporter) (log.LoggerProvider, func(ctx context.Context) error, error) {
+	severity := zapLevelToOTelSeverity(lg.Level())
+	for _, exporter := range exporters {
+		exp, err := newLogExporter(ctx, cfg, exporter)
+		if err != nil {
+			return nil, nil, err
+		}
 		logOptions = append(logOptions,
 			sdklog.WithProcessor(&levelFilterProcessor{
-				next:     sdklog.NewBatchProcessor(e),
-				severity: zapLevelToOTelSeverity(lg.Level()),
+				next:     sdklog.NewBatchProcessor(exp),
+				severity: severity,
 			}),
 		)
-		provider := sdklog.NewLoggerProvider(logOptions...)
-		return provider, provider.Shutdown, nil
 	}
-	exporter := strings.TrimSpace(getEnvOr("OTEL_LOGS_EXPORTER", expOTLP))
+
+	provider := sdklog.NewLoggerProvider(logOptions...)
+	return provider, provider.Shutdown, nil
+}
+
+func newLogExporter(ctx context.Context, cfg config, exporter string) (sdklog.Exporter, error) {
+	lg := zctx.From(ctx)
 	switch exporter {
 	case expOTLP:
 		proto := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
@@ -95,19 +117,19 @@ func NewLoggerProvider(ctx context.Context, options ...Option) (
 		case protoHTTP, protoHTTPProtobuf:
 			exp, err := otlploghttp.New(ctx)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "create OTLP HTTP logs exporter")
+				return nil, errors.Wrap(err, "create OTLP HTTP logs exporter")
 			}
-			return ret(exp)
+			return exp, nil
 		case protoGRPC:
 			exp, err := otlploggrpc.New(ctx)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "create OTLP gRPC logs exporter")
+				return nil, errors.Wrap(err, "create OTLP gRPC logs exporter")
 			}
-			return ret(exp)
+			return exp, nil
 		default:
-			return nil, nil, errors.Errorf("unsupported logs otlp protocol %q", proto)
+			return nil, errors.Errorf("unsupported logs otlp protocol %q", proto)
 		}
-	case writerStdout, writerStderr:
+	case writerStdout, writerStderr, expConsole:
 		lg.Debug("Using stdout log exporter", zap.String("writer", exporter))
 		writer := cfg.writer
 		if writer == nil {
@@ -115,12 +137,9 @@ func NewLoggerProvider(ctx context.Context, options ...Option) (
 		}
 		exp, err := stdoutlog.New(stdoutlog.WithWriter(writer))
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "create %q logs exporter", exporter)
+			return nil, errors.Wrapf(err, "create %q logs exporter", exporter)
 		}
-		return ret(exp)
-	case expNone:
-		lg.Debug("Using no-op logs exporter")
-		return noop.NewLoggerProvider(), nop, nil
+		return exp, nil
 	default:
 		lookup := cfg.lookup
 		if lookup == nil {
@@ -129,16 +148,16 @@ func NewLoggerProvider(ctx context.Context, options ...Option) (
 		lg.Debug("Looking for logs exporter", zap.String("exporter", exporter))
 		exp, ok, err := lookup(ctx, exporter)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "create %q", exporter)
+			return nil, errors.Wrapf(err, "create %q", exporter)
 		}
 		if !ok {
 			break
 		}
 
 		lg.Debug("Using user-defined log exporter", zap.String("exporter", exporter))
-		return ret(exp)
+		return exp, nil
 	}
-	return nil, nil, errors.Errorf("unsupported OTEL_LOGS_EXPORTER %q", exporter)
+	return nil, errors.Errorf("unsupported OTEL_LOGS_EXPORTER %q", exporter)
 }
 
 // levelFilterProcessor implements level filtering, since otlplog does not.

--- a/autologs/autologs.go
+++ b/autologs/autologs.go
@@ -84,17 +84,23 @@ func NewLoggerProvider(ctx context.Context, options ...Option) (
 		logOptions = append(logOptions, sdklog.WithResource(cfg.res))
 	}
 	severity := zapLevelToOTelSeverity(lg.Level())
-	for _, exporter := range exporters {
-		exp, err := newLogExporter(ctx, cfg, exporter)
-		if err != nil {
-			return nil, nil, err
-		}
+	addExporter := func(exp sdklog.Exporter) {
 		logOptions = append(logOptions,
 			sdklog.WithProcessor(&levelFilterProcessor{
 				next:     sdklog.NewBatchProcessor(exp),
 				severity: severity,
 			}),
 		)
+	}
+	for _, exporter := range exporters {
+		exp, err := newLogExporter(ctx, cfg, exporter)
+		if err != nil {
+			return nil, nil, err
+		}
+		addExporter(exp)
+	}
+	for _, exp := range cfg.additional {
+		addExporter(exp)
 	}
 
 	provider := sdklog.NewLoggerProvider(logOptions...)

--- a/autologs/autologs.go
+++ b/autologs/autologs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/go-faster/errors"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
@@ -61,6 +62,12 @@ type ShutdownFunc func(ctx context.Context) error
 // NewLoggerProvider initializes new [log.LoggerProvider] with the given options from environment variables.
 //
 // OTEL_LOGS_EXPORTER is a comma-separated list of exporters, all of them are used.
+// Exporters that fail to initialize are logged and skipped, error is returned only
+// if none of them could be set up.
+//
+// GOFASTER_OTLP_LOGS_ENDPOINTS (or GOFASTER_OTLP_ENDPOINTS) is a comma-separated
+// list of additional OTLP endpoints to fan out logs to. Not defined by the
+// OpenTelemetry specification, where OTEL_EXPORTER_OTLP_ENDPOINT is singular.
 func NewLoggerProvider(ctx context.Context, options ...Option) (
 	logProvider log.LoggerProvider,
 	logShutdown ShutdownFunc,
@@ -69,7 +76,10 @@ func NewLoggerProvider(ctx context.Context, options ...Option) (
 	cfg := newConfig(options)
 	lg := zctx.From(ctx)
 
-	const envName = "OTEL_LOGS_EXPORTER"
+	const (
+		signalName = "LOGS"
+		envName    = "OTEL_" + signalName + "_EXPORTER"
+	)
 	exporters, err := autoenv.ParseExporters(getEnvOr(envName, expOTLP))
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "parse %s", envName)
@@ -79,7 +89,11 @@ func NewLoggerProvider(ctx context.Context, options ...Option) (
 		return noop.NewLoggerProvider(), nop, nil
 	}
 
-	var logOptions []sdklog.LoggerProviderOption
+	var (
+		logOptions []sdklog.LoggerProviderOption
+		setupErrs  []error
+		configured int
+	)
 	if cfg.res != nil {
 		logOptions = append(logOptions, sdklog.WithResource(cfg.res))
 	}
@@ -91,50 +105,96 @@ func NewLoggerProvider(ctx context.Context, options ...Option) (
 				severity: severity,
 			}),
 		)
+		configured++
 	}
 	for _, exporter := range exporters {
 		exp, err := newLogExporter(ctx, cfg, exporter)
 		if err != nil {
-			return nil, nil, err
+			// Single broken exporter should not take down the rest of them.
+			lg.Warn("Failed to setup logs exporter",
+				zap.String("exporter", exporter),
+				zap.Error(err),
+			)
+			setupErrs = append(setupErrs, err)
+			continue
 		}
+		addExporter(exp)
+	}
+	for _, endpoint := range autoenv.AdditionalEndpoints(signalName) {
+		exp, err := newOTLPExporter(ctx, endpoint)
+		if err != nil {
+			lg.Warn("Failed to setup additional OTLP logs exporter",
+				zap.String("endpoint", endpoint),
+				zap.Error(err),
+			)
+			setupErrs = append(setupErrs, err)
+			continue
+		}
+		lg.Debug("Using additional OTLP logs exporter", zap.String("endpoint", endpoint))
 		addExporter(exp)
 	}
 	for _, exp := range cfg.additional {
 		addExporter(exp)
+	}
+	if configured == 0 {
+		return nil, nil, errors.Join(setupErrs...)
 	}
 
 	provider := sdklog.NewLoggerProvider(logOptions...)
 	return provider, provider.Shutdown, nil
 }
 
+// newOTLPExporter creates OTLP exporter, endpoint overrides OTEL_EXPORTER_OTLP_ENDPOINT if set.
+func newOTLPExporter(ctx context.Context, endpoint string) (sdklog.Exporter, error) {
+	lg := zctx.From(ctx)
+
+	proto := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
+	if proto == "" {
+		proto = os.Getenv("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL")
+	}
+	if proto == "" {
+		proto = defaultProto
+	}
+	lg.Debug("Using OTLP logs exporter", zap.String("protocol", proto))
+	switch proto {
+	case protoHTTP, protoHTTPProtobuf:
+		var opts []otlploghttp.Option
+		switch {
+		case endpoint == "":
+		case strings.Contains(endpoint, "://"):
+			opts = append(opts, otlploghttp.WithEndpointURL(endpoint))
+		default:
+			opts = append(opts, otlploghttp.WithEndpoint(endpoint))
+		}
+		exp, err := otlploghttp.New(ctx, opts...)
+		if err != nil {
+			return nil, errors.Wrap(err, "create OTLP HTTP logs exporter")
+		}
+		return exp, nil
+	case protoGRPC:
+		var opts []otlploggrpc.Option
+		switch {
+		case endpoint == "":
+		case strings.Contains(endpoint, "://"):
+			opts = append(opts, otlploggrpc.WithEndpointURL(endpoint))
+		default:
+			opts = append(opts, otlploggrpc.WithEndpoint(endpoint))
+		}
+		exp, err := otlploggrpc.New(ctx, opts...)
+		if err != nil {
+			return nil, errors.Wrap(err, "create OTLP gRPC logs exporter")
+		}
+		return exp, nil
+	default:
+		return nil, errors.Errorf("unsupported logs otlp protocol %q", proto)
+	}
+}
+
 func newLogExporter(ctx context.Context, cfg config, exporter string) (sdklog.Exporter, error) {
 	lg := zctx.From(ctx)
 	switch exporter {
 	case expOTLP:
-		proto := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
-		if proto == "" {
-			proto = os.Getenv("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL")
-		}
-		if proto == "" {
-			proto = defaultProto
-		}
-		lg.Debug("Using OTLP logs exporter", zap.String("protocol", proto))
-		switch proto {
-		case protoHTTP, protoHTTPProtobuf:
-			exp, err := otlploghttp.New(ctx)
-			if err != nil {
-				return nil, errors.Wrap(err, "create OTLP HTTP logs exporter")
-			}
-			return exp, nil
-		case protoGRPC:
-			exp, err := otlploggrpc.New(ctx)
-			if err != nil {
-				return nil, errors.Wrap(err, "create OTLP gRPC logs exporter")
-			}
-			return exp, nil
-		default:
-			return nil, errors.Errorf("unsupported logs otlp protocol %q", proto)
-		}
+		return newOTLPExporter(ctx, "")
 	case writerStdout, writerStderr, expConsole:
 		lg.Debug("Using stdout log exporter", zap.String("writer", exporter))
 		writer := cfg.writer

--- a/autologs/autologs_test.go
+++ b/autologs/autologs_test.go
@@ -3,6 +3,8 @@ package autologs_test
 import (
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -131,6 +133,51 @@ func TestNewLoggerProviderAdditionalExporters(t *testing.T) {
 
 		require.Empty(t, exporter.Records())
 	})
+}
+
+func TestNewLoggerProviderPartiallyUnsupported(t *testing.T) {
+	ctx := zctx.Base(context.Background(), zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)))
+	t.Setenv("OTEL_LOGS_EXPORTER", "unsupported,first")
+
+	exporter := &testLogExporter{}
+	provider, shutdown, err := autologs.NewLoggerProvider(ctx,
+		autologs.WithLookupExporter(func(ctx context.Context, name string) (sdklog.Exporter, bool, error) {
+			return exporter, name == "first", nil
+		}),
+	)
+	require.NoError(t, err)
+
+	otelLg := zap.New(otelzap.NewCore("test", otelzap.WithLoggerProvider(provider)))
+	otelLg.Info("information")
+	require.NoError(t, otelLg.Sync())
+	require.NoError(t, shutdown(ctx))
+
+	require.Len(t, exporter.Records(), 1)
+}
+
+func TestNewLoggerProviderAdditionalEndpoints(t *testing.T) {
+	ctx := zctx.Base(context.Background(), zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)))
+
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("OTEL_LOGS_EXPORTER", "stdout")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+	t.Setenv("GOFASTER_OTLP_LOGS_ENDPOINTS", srv.URL)
+
+	provider, shutdown, err := autologs.NewLoggerProvider(ctx, autologs.WithWriter(io.Discard))
+	require.NoError(t, err)
+
+	otelLg := zap.New(otelzap.NewCore("test", otelzap.WithLoggerProvider(provider)))
+	otelLg.Info("information")
+	require.NoError(t, otelLg.Sync())
+	require.NoError(t, shutdown(ctx))
+
+	require.Equal(t, int64(1), requests.Load())
 }
 
 func TestNewLoggerProviderNegative(t *testing.T) {

--- a/autologs/autologs_test.go
+++ b/autologs/autologs_test.go
@@ -2,6 +2,7 @@ package autologs_test
 
 import (
 	"context"
+	"io"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -92,6 +93,44 @@ func TestNewLoggerProviderMultipleExporters(t *testing.T) {
 		require.Lenf(t, records, 1, "exporter %q", name)
 		require.Equal(t, "information", records[0].Body().AsString())
 	}
+}
+
+func TestNewLoggerProviderAdditionalExporters(t *testing.T) {
+	ctx := zctx.Base(context.Background(), zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)))
+
+	t.Run("Additional", func(t *testing.T) {
+		t.Setenv("OTEL_LOGS_EXPORTER", "stdout")
+
+		exporter := &testLogExporter{}
+		provider, shutdown, err := autologs.NewLoggerProvider(ctx,
+			autologs.WithWriter(io.Discard),
+			autologs.WithAdditionalExporters(exporter),
+		)
+		require.NoError(t, err)
+
+		otelLg := zap.New(otelzap.NewCore("test", otelzap.WithLoggerProvider(provider)))
+		otelLg.Info("information")
+		require.NoError(t, otelLg.Sync())
+		require.NoError(t, shutdown(ctx))
+
+		require.Len(t, exporter.Records(), 1)
+	})
+	t.Run("None", func(t *testing.T) {
+		t.Setenv("OTEL_LOGS_EXPORTER", "none")
+
+		exporter := &testLogExporter{}
+		provider, shutdown, err := autologs.NewLoggerProvider(ctx,
+			autologs.WithAdditionalExporters(exporter),
+		)
+		require.NoError(t, err)
+
+		otelLg := zap.New(otelzap.NewCore("test", otelzap.WithLoggerProvider(provider)))
+		otelLg.Info("information")
+		require.NoError(t, otelLg.Sync())
+		require.NoError(t, shutdown(ctx))
+
+		require.Empty(t, exporter.Records())
+	})
 }
 
 func TestNewLoggerProviderNegative(t *testing.T) {

--- a/autologs/autologs_test.go
+++ b/autologs/autologs_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 
 	"github.com/go-faster/errors"
-	"github.com/go-faster/sdk/autologs"
-	"github.com/go-faster/sdk/zctx"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/contrib/bridges/otelzap"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
+
+	"github.com/go-faster/sdk/autologs"
+	"github.com/go-faster/sdk/zctx"
 )
 
 func TestNewLoggerProviderLevel(t *testing.T) {
@@ -57,6 +58,58 @@ func TestNewLoggerProviderLevel(t *testing.T) {
 		},
 		msgs,
 	)
+}
+
+func TestNewLoggerProviderMultipleExporters(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("OTEL_LOGS_EXPORTER", "first,second")
+	ctx = zctx.Base(ctx, zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)))
+
+	exporters := map[string]*testLogExporter{
+		"first":  {},
+		"second": {},
+	}
+	provider, shutdown, err := autologs.NewLoggerProvider(ctx,
+		autologs.WithLookupExporter(func(ctx context.Context, name string) (sdklog.Exporter, bool, error) {
+			exp, ok := exporters[name]
+			if !ok {
+				return nil, false, errors.Errorf("unexpected exporter %q", name)
+			}
+			return exp, true, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	otelLg := zap.New(otelzap.NewCore("github.com/go-faster/sdk/app",
+		otelzap.WithLoggerProvider(provider),
+	))
+	otelLg.Info("information")
+	require.NoError(t, otelLg.Sync())
+	require.NoError(t, shutdown(ctx))
+
+	for name, exp := range exporters {
+		records := exp.Records()
+		require.Lenf(t, records, 1, "exporter %q", name)
+		require.Equal(t, "information", records[0].Body().AsString())
+	}
+}
+
+func TestNewLoggerProviderNegative(t *testing.T) {
+	ctx := context.Background()
+	for _, exp := range []string{
+		"unsupported",
+		"none,stdout",
+		"stdout,none",
+		",",
+	} {
+		t.Run(exp, func(t *testing.T) {
+			t.Setenv("OTEL_LOGS_EXPORTER", exp)
+			provider, shutdown, err := autologs.NewLoggerProvider(ctx)
+			require.Error(t, err)
+			require.Nil(t, provider)
+			require.Nil(t, shutdown)
+		})
+	}
 }
 
 type testLogExporter struct {

--- a/autologs/config.go
+++ b/autologs/config.go
@@ -10,9 +10,10 @@ import (
 
 // config contains configuration options for a LoggerProvider.
 type config struct {
-	res    *resource.Resource
-	writer io.Writer
-	lookup LookupExporter
+	res        *resource.Resource
+	writer     io.Writer
+	lookup     LookupExporter
+	additional []sdklog.Exporter
 }
 
 // newConfig returns a config configured with options.
@@ -54,6 +55,17 @@ func WithResource(res *resource.Resource) Option {
 func WithWriter(out io.Writer) Option {
 	return optionFunc(func(conf config) config {
 		conf.writer = out
+		return conf
+	})
+}
+
+// WithAdditionalExporters adds exporters used in addition to the ones configured
+// by OTEL_LOGS_EXPORTER, e.g. to fan out logs to a second backend.
+//
+// Ignored if OTEL_LOGS_EXPORTER is set to "none".
+func WithAdditionalExporters(exporters ...sdklog.Exporter) Option {
+	return optionFunc(func(conf config) config {
+		conf.additional = append(conf.additional, exporters...)
 		return conf
 	})
 }

--- a/autometer/autometer.go
+++ b/autometer/autometer.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/go-faster/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -21,12 +20,14 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.uber.org/zap"
 
+	"github.com/go-faster/sdk/internal/autoenv"
 	"github.com/go-faster/sdk/zctx"
 )
 
 const (
 	expOTLP       = "otlp"
-	expNone       = "none" // no-op
+	expConsole    = "console"
+	expNone       = autoenv.ExporterNone // no-op
 	expPrometheus = "prometheus"
 
 	protoHTTP         = "http"
@@ -42,7 +43,7 @@ const (
 
 func writerByName(name string) io.Writer {
 	switch name {
-	case writerStdout:
+	case writerStdout, expConsole:
 		return os.Stdout
 	case writerStderr:
 		return os.Stderr
@@ -64,6 +65,8 @@ func noopHandler(_ context.Context) error { return nil }
 type ShutdownFunc func(ctx context.Context) error
 
 // NewMeterProvider returns new metric.MeterProvider based on environment variables.
+//
+// OTEL_METRICS_EXPORTER is a comma-separated list of exporters, all of them are used.
 func NewMeterProvider(ctx context.Context, options ...Option) (
 	meterProvider metric.MeterProvider,
 	meterShutdown ShutdownFunc,
@@ -71,19 +74,35 @@ func NewMeterProvider(ctx context.Context, options ...Option) (
 ) {
 	cfg := newConfig(options)
 	lg := zctx.From(ctx)
+
+	const envName = "OTEL_METRICS_EXPORTER"
+	exporters, err := autoenv.ParseExporters(getEnvOr(envName, expOTLP))
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "parse %s", envName)
+	}
+	if exporters[0] == expNone {
+		lg.Debug("Using no-op metrics exporter")
+		return noop.NewMeterProvider(), noopHandler, nil
+	}
+
 	var metricOptions []sdkmetric.Option
 	if cfg.res != nil {
 		metricOptions = append(metricOptions, sdkmetric.WithResource(cfg.res))
 	}
-
-	ret := func(r sdkmetric.Reader) (metric.MeterProvider, func(ctx context.Context) error, error) {
-		metricOptions = append(metricOptions, sdkmetric.WithReader(r))
-		provider := sdkmetric.NewMeterProvider(metricOptions...)
-		return provider, provider.Shutdown, nil
+	for _, exporter := range exporters {
+		reader, err := newMetricReader(ctx, cfg, exporter)
+		if err != nil {
+			return nil, nil, err
+		}
+		metricOptions = append(metricOptions, sdkmetric.WithReader(reader))
 	}
 
-	// Metrics exporter.
-	exporter := strings.TrimSpace(getEnvOr("OTEL_METRICS_EXPORTER", expOTLP))
+	provider := sdkmetric.NewMeterProvider(metricOptions...)
+	return provider, provider.Shutdown, nil
+}
+
+func newMetricReader(ctx context.Context, cfg config, exporter string) (sdkmetric.Reader, error) {
+	lg := zctx.From(ctx)
 	switch exporter {
 	case expPrometheus:
 		lg.Debug("Using Prometheus metrics exporter")
@@ -101,7 +120,7 @@ func NewMeterProvider(ctx context.Context, options ...Option) (
 			otelprometheus.WithRegisterer(reg),
 		)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "create Prometheus exporter")
+			return nil, errors.Wrap(err, "create Prometheus exporter")
 		}
 		// Register legacy prometheus-only runtime metrics for backward compatibility.
 		reg.MustRegister(
@@ -109,7 +128,7 @@ func NewMeterProvider(ctx context.Context, options ...Option) (
 			collectors.NewGoCollector(),
 			collectors.NewBuildInfoCollector(),
 		)
-		return ret(exp)
+		return exp, nil
 	case expOTLP:
 		proto := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
 		if proto == "" {
@@ -123,19 +142,19 @@ func NewMeterProvider(ctx context.Context, options ...Option) (
 		case protoHTTP, protoHTTPProtobuf:
 			exp, err := otlpmetrichttp.New(ctx)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "create OTLP HTTP metric exporter")
+				return nil, errors.Wrap(err, "create OTLP HTTP metric exporter")
 			}
-			return ret(sdkmetric.NewPeriodicReader(exp))
+			return sdkmetric.NewPeriodicReader(exp), nil
 		case protoGRPC:
 			exp, err := otlpmetricgrpc.New(ctx)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "create OTLP gRPC metric exporter")
+				return nil, errors.Wrap(err, "create OTLP gRPC metric exporter")
 			}
-			return ret(sdkmetric.NewPeriodicReader(exp))
+			return sdkmetric.NewPeriodicReader(exp), nil
 		default:
-			return nil, nil, errors.Errorf("unsupported metric OTLP protocol %q", proto)
+			return nil, errors.Errorf("unsupported metric OTLP protocol %q", proto)
 		}
-	case writerStdout, writerStderr:
+	case writerStdout, writerStderr, expConsole:
 		lg.Debug("Using stdout metrics exporter", zap.String("writer", exporter))
 		writer := cfg.writer
 		if writer == nil {
@@ -144,12 +163,9 @@ func NewMeterProvider(ctx context.Context, options ...Option) (
 		enc := json.NewEncoder(writer)
 		exp, err := stdoutmetric.New(stdoutmetric.WithEncoder(enc))
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "create %q metric exporter", exporter)
+			return nil, errors.Wrapf(err, "create %q metric exporter", exporter)
 		}
-		return ret(sdkmetric.NewPeriodicReader(exp))
-	case expNone:
-		lg.Debug("Using no-op metrics exporter")
-		return noop.NewMeterProvider(), noopHandler, nil
+		return sdkmetric.NewPeriodicReader(exp), nil
 	default:
 		lookup := cfg.lookup
 		if lookup == nil {
@@ -158,14 +174,14 @@ func NewMeterProvider(ctx context.Context, options ...Option) (
 		lg.Debug("Looking for metrics exporter", zap.String("exporter", exporter))
 		exp, ok, err := lookup(ctx, exporter)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "create %q", exporter)
+			return nil, errors.Wrapf(err, "create %q", exporter)
 		}
 		if !ok {
 			break
 		}
 
 		lg.Debug("Using user-defined metrics exporter", zap.String("exporter", exporter))
-		return ret(exp)
+		return exp, nil
 	}
-	return nil, nil, errors.Errorf("unsupported OTEL_METRICS_EXPORTER %q", exporter)
+	return nil, errors.Errorf("unsupported OTEL_METRICS_EXPORTER %q", exporter)
 }

--- a/autometer/autometer.go
+++ b/autometer/autometer.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/go-faster/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -67,6 +68,12 @@ type ShutdownFunc func(ctx context.Context) error
 // NewMeterProvider returns new metric.MeterProvider based on environment variables.
 //
 // OTEL_METRICS_EXPORTER is a comma-separated list of exporters, all of them are used.
+// Exporters that fail to initialize are logged and skipped, error is returned only
+// if none of them could be set up.
+//
+// GOFASTER_OTLP_METRICS_ENDPOINTS (or GOFASTER_OTLP_ENDPOINTS) is a comma-separated
+// list of additional OTLP endpoints to fan out metrics to. Not defined by the
+// OpenTelemetry specification, where OTEL_EXPORTER_OTLP_ENDPOINT is singular.
 func NewMeterProvider(ctx context.Context, options ...Option) (
 	meterProvider metric.MeterProvider,
 	meterShutdown ShutdownFunc,
@@ -75,7 +82,10 @@ func NewMeterProvider(ctx context.Context, options ...Option) (
 	cfg := newConfig(options)
 	lg := zctx.From(ctx)
 
-	const envName = "OTEL_METRICS_EXPORTER"
+	const (
+		signalName = "METRICS"
+		envName    = "OTEL_" + signalName + "_EXPORTER"
+	)
 	exporters, err := autoenv.ParseExporters(getEnvOr(envName, expOTLP))
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "parse %s", envName)
@@ -85,23 +95,99 @@ func NewMeterProvider(ctx context.Context, options ...Option) (
 		return noop.NewMeterProvider(), noopHandler, nil
 	}
 
-	var metricOptions []sdkmetric.Option
+	var (
+		metricOptions []sdkmetric.Option
+		setupErrs     []error
+		configured    int
+	)
 	if cfg.res != nil {
 		metricOptions = append(metricOptions, sdkmetric.WithResource(cfg.res))
+	}
+	addReader := func(r sdkmetric.Reader) {
+		metricOptions = append(metricOptions, sdkmetric.WithReader(r))
+		configured++
 	}
 	for _, exporter := range exporters {
 		reader, err := newMetricReader(ctx, cfg, exporter)
 		if err != nil {
-			return nil, nil, err
+			// Single broken exporter should not take down the rest of them.
+			lg.Warn("Failed to setup metrics exporter",
+				zap.String("exporter", exporter),
+				zap.Error(err),
+			)
+			setupErrs = append(setupErrs, err)
+			continue
 		}
-		metricOptions = append(metricOptions, sdkmetric.WithReader(reader))
+		addReader(reader)
+	}
+	for _, endpoint := range autoenv.AdditionalEndpoints(signalName) {
+		reader, err := newOTLPReader(ctx, endpoint)
+		if err != nil {
+			lg.Warn("Failed to setup additional OTLP metrics exporter",
+				zap.String("endpoint", endpoint),
+				zap.Error(err),
+			)
+			setupErrs = append(setupErrs, err)
+			continue
+		}
+		lg.Debug("Using additional OTLP metrics exporter", zap.String("endpoint", endpoint))
+		addReader(reader)
 	}
 	for _, reader := range cfg.additional {
-		metricOptions = append(metricOptions, sdkmetric.WithReader(reader))
+		addReader(reader)
+	}
+	if configured == 0 {
+		return nil, nil, errors.Join(setupErrs...)
 	}
 
 	provider := sdkmetric.NewMeterProvider(metricOptions...)
 	return provider, provider.Shutdown, nil
+}
+
+// newOTLPReader creates OTLP reader, endpoint overrides OTEL_EXPORTER_OTLP_ENDPOINT if set.
+func newOTLPReader(ctx context.Context, endpoint string) (sdkmetric.Reader, error) {
+	lg := zctx.From(ctx)
+
+	proto := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
+	if proto == "" {
+		proto = os.Getenv("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL")
+	}
+	if proto == "" {
+		proto = defaultProto
+	}
+	lg.Debug("Using OTLP metrics exporter", zap.String("protocol", proto))
+	switch proto {
+	case protoHTTP, protoHTTPProtobuf:
+		var opts []otlpmetrichttp.Option
+		switch {
+		case endpoint == "":
+		case strings.Contains(endpoint, "://"):
+			opts = append(opts, otlpmetrichttp.WithEndpointURL(endpoint))
+		default:
+			opts = append(opts, otlpmetrichttp.WithEndpoint(endpoint))
+		}
+		exp, err := otlpmetrichttp.New(ctx, opts...)
+		if err != nil {
+			return nil, errors.Wrap(err, "create OTLP HTTP metric exporter")
+		}
+		return sdkmetric.NewPeriodicReader(exp), nil
+	case protoGRPC:
+		var opts []otlpmetricgrpc.Option
+		switch {
+		case endpoint == "":
+		case strings.Contains(endpoint, "://"):
+			opts = append(opts, otlpmetricgrpc.WithEndpointURL(endpoint))
+		default:
+			opts = append(opts, otlpmetricgrpc.WithEndpoint(endpoint))
+		}
+		exp, err := otlpmetricgrpc.New(ctx, opts...)
+		if err != nil {
+			return nil, errors.Wrap(err, "create OTLP gRPC metric exporter")
+		}
+		return sdkmetric.NewPeriodicReader(exp), nil
+	default:
+		return nil, errors.Errorf("unsupported metric OTLP protocol %q", proto)
+	}
 }
 
 func newMetricReader(ctx context.Context, cfg config, exporter string) (sdkmetric.Reader, error) {
@@ -133,30 +219,7 @@ func newMetricReader(ctx context.Context, cfg config, exporter string) (sdkmetri
 		)
 		return exp, nil
 	case expOTLP:
-		proto := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
-		if proto == "" {
-			proto = os.Getenv("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL")
-		}
-		if proto == "" {
-			proto = defaultProto
-		}
-		lg.Debug("Using OTLP metrics exporter", zap.String("protocol", proto))
-		switch proto {
-		case protoHTTP, protoHTTPProtobuf:
-			exp, err := otlpmetrichttp.New(ctx)
-			if err != nil {
-				return nil, errors.Wrap(err, "create OTLP HTTP metric exporter")
-			}
-			return sdkmetric.NewPeriodicReader(exp), nil
-		case protoGRPC:
-			exp, err := otlpmetricgrpc.New(ctx)
-			if err != nil {
-				return nil, errors.Wrap(err, "create OTLP gRPC metric exporter")
-			}
-			return sdkmetric.NewPeriodicReader(exp), nil
-		default:
-			return nil, errors.Errorf("unsupported metric OTLP protocol %q", proto)
-		}
+		return newOTLPReader(ctx, "")
 	case writerStdout, writerStderr, expConsole:
 		lg.Debug("Using stdout metrics exporter", zap.String("writer", exporter))
 		writer := cfg.writer

--- a/autometer/autometer.go
+++ b/autometer/autometer.go
@@ -96,6 +96,9 @@ func NewMeterProvider(ctx context.Context, options ...Option) (
 		}
 		metricOptions = append(metricOptions, sdkmetric.WithReader(reader))
 	}
+	for _, reader := range cfg.additional {
+		metricOptions = append(metricOptions, sdkmetric.WithReader(reader))
+	}
 
 	provider := sdkmetric.NewMeterProvider(metricOptions...)
 	return provider, provider.Shutdown, nil

--- a/autometer/autometer_test.go
+++ b/autometer/autometer_test.go
@@ -3,6 +3,9 @@ package autometer_test
 import (
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-faster/errors"
@@ -42,6 +45,53 @@ func TestNewMeterProvider(t *testing.T) {
 				require.Nil(t, stop)
 			})
 		}
+	})
+	t.Run("PartiallyUnsupported", func(t *testing.T) {
+		t.Setenv("OTEL_METRICS_EXPORTER", "unsupported,first")
+
+		reader := sdkmetric.NewManualReader()
+		meter, stop, err := autometer.NewMeterProvider(ctx,
+			autometer.WithResource(res),
+			autometer.WithLookupExporter(func(ctx context.Context, name string) (sdkmetric.Reader, bool, error) {
+				return reader, name == "first", nil
+			}),
+		)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, stop(ctx)) }()
+
+		counter, err := meter.Meter("test").Int64Counter("test_counter")
+		require.NoError(t, err)
+		counter.Add(ctx, 1)
+
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(ctx, &rm))
+		require.Len(t, rm.ScopeMetrics, 1)
+	})
+	t.Run("AdditionalEndpoints", func(t *testing.T) {
+		var requests atomic.Int64
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		t.Setenv("OTEL_METRICS_EXPORTER", "stdout")
+		t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+		t.Setenv("GOFASTER_OTLP_METRICS_ENDPOINTS", srv.URL)
+
+		meter, stop, err := autometer.NewMeterProvider(ctx,
+			autometer.WithResource(res),
+			autometer.WithWriter(io.Discard),
+		)
+		require.NoError(t, err)
+
+		counter, err := meter.Meter("test").Int64Counter("test_counter")
+		require.NoError(t, err)
+		counter.Add(ctx, 1)
+
+		// Shutdown flushes readers.
+		require.NoError(t, stop(ctx))
+		require.Equal(t, int64(1), requests.Load())
 	})
 	t.Run("Additional", func(t *testing.T) {
 		t.Setenv("OTEL_METRICS_EXPORTER", "stdout")

--- a/autometer/autometer_test.go
+++ b/autometer/autometer_test.go
@@ -43,6 +43,44 @@ func TestNewMeterProvider(t *testing.T) {
 			})
 		}
 	})
+	t.Run("Additional", func(t *testing.T) {
+		t.Setenv("OTEL_METRICS_EXPORTER", "stdout")
+
+		reader := sdkmetric.NewManualReader()
+		meter, stop, err := autometer.NewMeterProvider(ctx,
+			autometer.WithResource(res),
+			autometer.WithWriter(io.Discard),
+			autometer.WithAdditionalExporters(reader),
+		)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, stop(ctx)) }()
+
+		counter, err := meter.Meter("test").Int64Counter("test_counter")
+		require.NoError(t, err)
+		counter.Add(ctx, 1)
+
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(ctx, &rm))
+		require.Len(t, rm.ScopeMetrics, 1)
+	})
+	t.Run("AdditionalNone", func(t *testing.T) {
+		t.Setenv("OTEL_METRICS_EXPORTER", "none")
+
+		reader := sdkmetric.NewManualReader()
+		meter, stop, err := autometer.NewMeterProvider(ctx,
+			autometer.WithResource(res),
+			autometer.WithAdditionalExporters(reader),
+		)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, stop(ctx)) }()
+
+		counter, err := meter.Meter("test").Int64Counter("test_counter")
+		require.NoError(t, err)
+		counter.Add(ctx, 1)
+
+		var rm metricdata.ResourceMetrics
+		require.ErrorContains(t, reader.Collect(ctx, &rm), "not registered")
+	})
 	t.Run("Multiple", func(t *testing.T) {
 		t.Setenv("OTEL_METRICS_EXPORTER", "first,second")
 

--- a/autometer/autometer_test.go
+++ b/autometer/autometer_test.go
@@ -5,7 +5,10 @@ import (
 	"io"
 	"testing"
 
+	"github.com/go-faster/errors"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 
 	"github.com/go-faster/sdk/autometer"
@@ -25,19 +28,63 @@ func TestNewMeterProvider(t *testing.T) {
 		require.NoError(t, stop(ctx))
 	})
 	t.Run("Negative", func(t *testing.T) {
-		t.Setenv("OTEL_METRICS_EXPORTER", "unsupported")
-		meter, stop, err := autometer.NewMeterProvider(ctx, autometer.WithResource(res))
-		require.Error(t, err)
-		require.Nil(t, meter)
-		require.Nil(t, stop)
+		for _, exp := range []string{
+			"unsupported",
+			"none,stdout",
+			"stdout,none",
+			",",
+		} {
+			t.Run(exp, func(t *testing.T) {
+				t.Setenv("OTEL_METRICS_EXPORTER", exp)
+				meter, stop, err := autometer.NewMeterProvider(ctx, autometer.WithResource(res))
+				require.Error(t, err)
+				require.Nil(t, meter)
+				require.Nil(t, stop)
+			})
+		}
+	})
+	t.Run("Multiple", func(t *testing.T) {
+		t.Setenv("OTEL_METRICS_EXPORTER", "first,second")
+
+		readers := map[string]*sdkmetric.ManualReader{
+			"first":  sdkmetric.NewManualReader(),
+			"second": sdkmetric.NewManualReader(),
+		}
+		meter, stop, err := autometer.NewMeterProvider(ctx,
+			autometer.WithResource(res),
+			autometer.WithLookupExporter(func(ctx context.Context, name string) (sdkmetric.Reader, bool, error) {
+				reader, ok := readers[name]
+				if !ok {
+					return nil, false, errors.Errorf("unexpected exporter %q", name)
+				}
+				return reader, true, nil
+			}),
+		)
+		require.NoError(t, err)
+
+		counter, err := meter.Meter("test").Int64Counter("test_counter")
+		require.NoError(t, err)
+		counter.Add(ctx, 1)
+
+		for name, reader := range readers {
+			var rm metricdata.ResourceMetrics
+			require.NoErrorf(t, reader.Collect(ctx, &rm), "reader %q", name)
+			require.Lenf(t, rm.ScopeMetrics, 1, "reader %q", name)
+			require.Lenf(t, rm.ScopeMetrics[0].Metrics, 1, "reader %q", name)
+			require.Equal(t, "test_counter", rm.ScopeMetrics[0].Metrics[0].Name)
+		}
+		require.NoError(t, stop(ctx))
 	})
 	t.Run("All", func(t *testing.T) {
 		for _, exp := range []string{
 			"none",
 			"stdout",
 			"stderr",
+			"console",
 			// "otlp", // TODO: add non-blocking dial
 			"prometheus",
+			"stdout,stderr",
+			"stdout,stdout",
 		} {
 			t.Run(exp, func(t *testing.T) {
 				t.Setenv("OTEL_METRICS_EXPORTER", exp)

--- a/autometer/config.go
+++ b/autometer/config.go
@@ -11,9 +11,10 @@ import (
 
 // config contains configuration options for a MeterProvider.
 type config struct {
-	res    *resource.Resource
-	writer io.Writer
-	lookup LookupExporter
+	res        *resource.Resource
+	writer     io.Writer
+	lookup     LookupExporter
+	additional []sdkmetric.Reader
 
 	prom         prometheus.Registerer
 	promCallback func(reg *prometheus.Registry)
@@ -72,6 +73,17 @@ func WithOnPrometheusRegistry(f func(reg *prometheus.Registry)) Option {
 func WithWriter(out io.Writer) Option {
 	return optionFunc(func(conf config) config {
 		conf.writer = out
+		return conf
+	})
+}
+
+// WithAdditionalExporters adds readers used in addition to the ones configured
+// by OTEL_METRICS_EXPORTER, e.g. to fan out metrics to a second backend.
+//
+// Ignored if OTEL_METRICS_EXPORTER is set to "none".
+func WithAdditionalExporters(readers ...sdkmetric.Reader) Option {
+	return optionFunc(func(conf config) config {
+		conf.additional = append(conf.additional, readers...)
 		return conf
 	})
 }

--- a/autotracer/autotracer.go
+++ b/autotracer/autotracer.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/go-faster/errors"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -62,6 +63,12 @@ type ShutdownFunc func(ctx context.Context) error
 // from environment variables.
 //
 // OTEL_TRACES_EXPORTER is a comma-separated list of exporters, all of them are used.
+// Exporters that fail to initialize are logged and skipped, error is returned only
+// if none of them could be set up.
+//
+// GOFASTER_OTLP_TRACES_ENDPOINTS (or GOFASTER_OTLP_ENDPOINTS) is a comma-separated
+// list of additional OTLP endpoints to fan out spans to. Not defined by the
+// OpenTelemetry specification, where OTEL_EXPORTER_OTLP_ENDPOINT is singular.
 func NewTracerProvider(ctx context.Context, options ...Option) (
 	tracerProvider trace.TracerProvider,
 	tracerShutdown ShutdownFunc,
@@ -70,7 +77,10 @@ func NewTracerProvider(ctx context.Context, options ...Option) (
 	cfg := newConfig(options)
 	lg := zctx.From(ctx)
 
-	const envName = "OTEL_TRACES_EXPORTER"
+	const (
+		signalName = "TRACES"
+		envName    = "OTEL_" + signalName + "_EXPORTER"
+	)
 	exporters, err := autoenv.ParseExporters(getEnvOr(envName, expOTLP))
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "parse %s", envName)
@@ -80,53 +90,106 @@ func NewTracerProvider(ctx context.Context, options ...Option) (
 		return noop.NewTracerProvider(), nop, nil
 	}
 
-	var traceOptions []sdktrace.TracerProviderOption
+	var (
+		traceOptions []sdktrace.TracerProviderOption
+		setupErrs    []error
+		configured   int
+	)
 	if cfg.res != nil {
 		traceOptions = append(traceOptions, sdktrace.WithResource(cfg.res))
+	}
+	addExporter := func(e sdktrace.SpanExporter) {
+		traceOptions = append(traceOptions, sdktrace.WithBatcher(e))
+		configured++
 	}
 	for _, exporter := range exporters {
 		exp, err := newSpanExporter(ctx, cfg, exporter)
 		if err != nil {
-			return nil, nil, err
+			// Single broken exporter should not take down the rest of them.
+			lg.Warn("Failed to setup trace exporter",
+				zap.String("exporter", exporter),
+				zap.Error(err),
+			)
+			setupErrs = append(setupErrs, err)
+			continue
 		}
-		traceOptions = append(traceOptions, sdktrace.WithBatcher(exp))
+		addExporter(exp)
+	}
+	for _, endpoint := range autoenv.AdditionalEndpoints(signalName) {
+		exp, err := newOTLPExporter(ctx, endpoint)
+		if err != nil {
+			lg.Warn("Failed to setup additional OTLP trace exporter",
+				zap.String("endpoint", endpoint),
+				zap.Error(err),
+			)
+			setupErrs = append(setupErrs, err)
+			continue
+		}
+		lg.Debug("Using additional OTLP trace exporter", zap.String("endpoint", endpoint))
+		addExporter(exp)
 	}
 	for _, exp := range cfg.additional {
-		traceOptions = append(traceOptions, sdktrace.WithBatcher(exp))
+		addExporter(exp)
+	}
+	if configured == 0 {
+		return nil, nil, errors.Join(setupErrs...)
 	}
 
 	provider := sdktrace.NewTracerProvider(traceOptions...)
 	return provider, provider.Shutdown, nil
 }
 
+// newOTLPExporter creates OTLP exporter, endpoint overrides OTEL_EXPORTER_OTLP_ENDPOINT if set.
+func newOTLPExporter(ctx context.Context, endpoint string) (sdktrace.SpanExporter, error) {
+	lg := zctx.From(ctx)
+
+	proto := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
+	if proto == "" {
+		proto = os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
+	}
+	if proto == "" {
+		proto = defaultProto
+	}
+	lg.Debug("Using OTLP trace exporter", zap.String("protocol", proto))
+	switch proto {
+	case protoHTTP, protoHTTPProtobuf:
+		var opts []otlptracehttp.Option
+		switch {
+		case endpoint == "":
+		case strings.Contains(endpoint, "://"):
+			opts = append(opts, otlptracehttp.WithEndpointURL(endpoint))
+		default:
+			opts = append(opts, otlptracehttp.WithEndpoint(endpoint))
+		}
+		exp, err := otlptracehttp.New(ctx, opts...)
+		if err != nil {
+			return nil, errors.Wrap(err, "create OTLP HTTP trace exporter")
+		}
+		return exp, nil
+	case protoGRPC:
+		var opts []otlptracegrpc.Option
+		switch {
+		case endpoint == "":
+		case strings.Contains(endpoint, "://"):
+			opts = append(opts, otlptracegrpc.WithEndpointURL(endpoint))
+		default:
+			opts = append(opts, otlptracegrpc.WithEndpoint(endpoint))
+		}
+		exp, err := otlptracegrpc.New(ctx, opts...)
+		if err != nil {
+			return nil, errors.Wrap(err, "create OTLP gRPC trace exporter")
+		}
+		return exp, nil
+	default:
+		return nil, errors.Errorf("unsupported traces otlp protocol %q", proto)
+	}
+}
+
 func newSpanExporter(ctx context.Context, cfg config, exporter string) (sdktrace.SpanExporter, error) {
 	lg := zctx.From(ctx)
 	switch exporter {
 	case expOTLP:
-		proto := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
-		if proto == "" {
-			proto = os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
-		}
-		if proto == "" {
-			proto = defaultProto
-		}
-		lg.Debug("Using OTLP trace exporter", zap.String("protocol", proto))
-		switch proto {
-		case protoHTTP, protoHTTPProtobuf:
-			exp, err := otlptracehttp.New(ctx)
-			if err != nil {
-				return nil, errors.Wrap(err, "create OTLP HTTP trace exporter")
-			}
-			return exp, nil
-		case protoGRPC:
-			exp, err := otlptracegrpc.New(ctx)
-			if err != nil {
-				return nil, errors.Wrap(err, "create OTLP gRPC trace exporter")
-			}
-			return exp, nil
-		default:
-			return nil, errors.Errorf("unsupported traces otlp protocol %q", proto)
-		}
+		return newOTLPExporter(ctx, "")
 	case writerStdout, writerStderr, expConsole:
 		lg.Debug("Using stdout trace exporter", zap.String("writer", exporter))
 		writer := cfg.writer

--- a/autotracer/autotracer.go
+++ b/autotracer/autotracer.go
@@ -91,6 +91,9 @@ func NewTracerProvider(ctx context.Context, options ...Option) (
 		}
 		traceOptions = append(traceOptions, sdktrace.WithBatcher(exp))
 	}
+	for _, exp := range cfg.additional {
+		traceOptions = append(traceOptions, sdktrace.WithBatcher(exp))
+	}
 
 	provider := sdktrace.NewTracerProvider(traceOptions...)
 	return provider, provider.Shutdown, nil

--- a/autotracer/autotracer.go
+++ b/autotracer/autotracer.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/go-faster/errors"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -17,12 +16,14 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/zap"
 
+	"github.com/go-faster/sdk/internal/autoenv"
 	"github.com/go-faster/sdk/zctx"
 )
 
 const (
-	expOTLP = "otlp"
-	expNone = "none" // no-op
+	expOTLP    = "otlp"
+	expConsole = "console"
+	expNone    = autoenv.ExporterNone // no-op
 
 	protoHTTP         = "http"
 	protoHTTPProtobuf = "http/protobuf"
@@ -37,7 +38,7 @@ const (
 
 func writerByName(name string) io.Writer {
 	switch name {
-	case writerStdout:
+	case writerStdout, expConsole:
 		return os.Stdout
 	case writerStderr:
 		return os.Stderr
@@ -57,6 +58,10 @@ func nop(_ context.Context) error { return nil }
 
 type ShutdownFunc func(ctx context.Context) error
 
+// NewTracerProvider initializes new [trace.TracerProvider] with the given options
+// from environment variables.
+//
+// OTEL_TRACES_EXPORTER is a comma-separated list of exporters, all of them are used.
 func NewTracerProvider(ctx context.Context, options ...Option) (
 	tracerProvider trace.TracerProvider,
 	tracerShutdown ShutdownFunc,
@@ -64,17 +69,35 @@ func NewTracerProvider(ctx context.Context, options ...Option) (
 ) {
 	cfg := newConfig(options)
 	lg := zctx.From(ctx)
+
+	const envName = "OTEL_TRACES_EXPORTER"
+	exporters, err := autoenv.ParseExporters(getEnvOr(envName, expOTLP))
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "parse %s", envName)
+	}
+	if exporters[0] == expNone {
+		lg.Debug("Using no-op trace exporter")
+		return noop.NewTracerProvider(), nop, nil
+	}
+
 	var traceOptions []sdktrace.TracerProviderOption
 	if cfg.res != nil {
 		traceOptions = append(traceOptions, sdktrace.WithResource(cfg.res))
 	}
-	ret := func(e sdktrace.SpanExporter) (trace.TracerProvider, func(ctx context.Context) error, error) {
-		traceOptions = append(traceOptions, sdktrace.WithBatcher(e))
-		provider := sdktrace.NewTracerProvider(traceOptions...)
-		return provider, provider.Shutdown, nil
+	for _, exporter := range exporters {
+		exp, err := newSpanExporter(ctx, cfg, exporter)
+		if err != nil {
+			return nil, nil, err
+		}
+		traceOptions = append(traceOptions, sdktrace.WithBatcher(exp))
 	}
 
-	exporter := strings.TrimSpace(getEnvOr("OTEL_TRACES_EXPORTER", expOTLP))
+	provider := sdktrace.NewTracerProvider(traceOptions...)
+	return provider, provider.Shutdown, nil
+}
+
+func newSpanExporter(ctx context.Context, cfg config, exporter string) (sdktrace.SpanExporter, error) {
+	lg := zctx.From(ctx)
 	switch exporter {
 	case expOTLP:
 		proto := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
@@ -89,19 +112,19 @@ func NewTracerProvider(ctx context.Context, options ...Option) (
 		case protoHTTP, protoHTTPProtobuf:
 			exp, err := otlptracehttp.New(ctx)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "create OTLP HTTP trace exporter")
+				return nil, errors.Wrap(err, "create OTLP HTTP trace exporter")
 			}
-			return ret(exp)
+			return exp, nil
 		case protoGRPC:
 			exp, err := otlptracegrpc.New(ctx)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "create OTLP gRPC trace exporter")
+				return nil, errors.Wrap(err, "create OTLP gRPC trace exporter")
 			}
-			return ret(exp)
+			return exp, nil
 		default:
-			return nil, nil, errors.Errorf("unsupported traces otlp protocol %q", proto)
+			return nil, errors.Errorf("unsupported traces otlp protocol %q", proto)
 		}
-	case writerStdout, writerStderr:
+	case writerStdout, writerStderr, expConsole:
 		lg.Debug("Using stdout trace exporter", zap.String("writer", exporter))
 		writer := cfg.writer
 		if writer == nil {
@@ -109,12 +132,9 @@ func NewTracerProvider(ctx context.Context, options ...Option) (
 		}
 		exp, err := stdouttrace.New(stdouttrace.WithWriter(writer))
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "create %q trace exporter", exporter)
+			return nil, errors.Wrapf(err, "create %q trace exporter", exporter)
 		}
-		return ret(exp)
-	case expNone:
-		lg.Debug("Using no-op trace exporter")
-		return noop.NewTracerProvider(), nop, nil
+		return exp, nil
 	default:
 		lookup := cfg.lookup
 		if lookup == nil {
@@ -123,14 +143,14 @@ func NewTracerProvider(ctx context.Context, options ...Option) (
 		lg.Debug("Looking for traces exporter", zap.String("exporter", exporter))
 		exp, ok, err := lookup(ctx, exporter)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "create %q", exporter)
+			return nil, errors.Wrapf(err, "create %q", exporter)
 		}
 		if !ok {
 			break
 		}
 
 		lg.Debug("Using user-defined traces exporter", zap.String("exporter", exporter))
-		return ret(exp)
+		return exp, nil
 	}
-	return nil, nil, errors.Errorf("unsupported OTEL_TRACES_EXPORTER %q", exporter)
+	return nil, errors.Errorf("unsupported OTEL_TRACES_EXPORTER %q", exporter)
 }

--- a/autotracer/autotracer_test.go
+++ b/autotracer/autotracer_test.go
@@ -1,0 +1,89 @@
+package autotracer_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/go-faster/sdk/autotracer"
+)
+
+func TestNewTracerProvider(t *testing.T) {
+	ctx := context.Background()
+	t.Run("All", func(t *testing.T) {
+		for _, exp := range []string{
+			"none",
+			"stdout",
+			"stderr",
+			"console",
+			// "otlp", // TODO: add non-blocking dial
+			"stdout,stderr",
+			"stdout,stdout",
+		} {
+			t.Run(exp, func(t *testing.T) {
+				t.Setenv("OTEL_TRACES_EXPORTER", exp)
+				tracer, stop, err := autotracer.NewTracerProvider(ctx, autotracer.WithWriter(io.Discard))
+				require.NoError(t, err)
+				require.NotNil(t, tracer)
+				require.NotNil(t, stop)
+
+				_, span := tracer.Tracer("test").Start(ctx, "test")
+				span.End()
+				require.NoError(t, stop(ctx))
+			})
+		}
+	})
+	t.Run("Negative", func(t *testing.T) {
+		for _, exp := range []string{
+			"unsupported",
+			"none,stdout",
+			"stdout,none",
+			",",
+		} {
+			t.Run(exp, func(t *testing.T) {
+				t.Setenv("OTEL_TRACES_EXPORTER", exp)
+				tracer, stop, err := autotracer.NewTracerProvider(ctx, autotracer.WithWriter(io.Discard))
+				require.Error(t, err)
+				require.Nil(t, tracer)
+				require.Nil(t, stop)
+			})
+		}
+	})
+	t.Run("Multiple", func(t *testing.T) {
+		t.Setenv("OTEL_TRACES_EXPORTER", "first,second")
+
+		exporters := map[string]*tracetest.InMemoryExporter{
+			"first":  tracetest.NewInMemoryExporter(),
+			"second": tracetest.NewInMemoryExporter(),
+		}
+		tracer, stop, err := autotracer.NewTracerProvider(ctx,
+			autotracer.WithLookupExporter(func(ctx context.Context, name string) (sdktrace.SpanExporter, bool, error) {
+				exp, ok := exporters[name]
+				if !ok {
+					return nil, false, errors.Errorf("unexpected exporter %q", name)
+				}
+				return exp, true, nil
+			}),
+		)
+		require.NoError(t, err)
+
+		_, span := tracer.Tracer("test").Start(ctx, "test")
+		span.End()
+		// InMemoryExporter resets records on shutdown.
+		require.NoError(t, tracer.(interface {
+			ForceFlush(ctx context.Context) error
+		}).ForceFlush(ctx))
+		defer func() { require.NoError(t, stop(ctx)) }()
+
+		for name, exp := range exporters {
+			spans := exp.GetSpans()
+			require.Lenf(t, spans, 1, "exporter %q", name)
+			require.Equal(t, "test", spans[0].Name)
+		}
+	})
+}

--- a/autotracer/autotracer_test.go
+++ b/autotracer/autotracer_test.go
@@ -3,6 +3,9 @@ package autotracer_test
 import (
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-faster/errors"
@@ -49,6 +52,46 @@ func TestNewTracerProvider(t *testing.T) {
 				require.NoError(t, stop(ctx))
 			})
 		}
+	})
+	t.Run("PartiallyUnsupported", func(t *testing.T) {
+		t.Setenv("OTEL_TRACES_EXPORTER", "unsupported,first")
+
+		exp := tracetest.NewInMemoryExporter()
+		tracer, stop, err := autotracer.NewTracerProvider(ctx,
+			autotracer.WithLookupExporter(func(ctx context.Context, name string) (sdktrace.SpanExporter, bool, error) {
+				return exp, name == "first", nil
+			}),
+		)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, stop(ctx)) }()
+
+		_, span := tracer.Tracer("test").Start(ctx, "test")
+		span.End()
+		forceFlush(t, ctx, tracer)
+
+		require.Len(t, exp.GetSpans(), 1)
+	})
+	t.Run("AdditionalEndpoints", func(t *testing.T) {
+		var requests atomic.Int64
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		t.Setenv("OTEL_TRACES_EXPORTER", "stdout")
+		t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+		t.Setenv("GOFASTER_OTLP_TRACES_ENDPOINTS", srv.URL)
+
+		tracer, stop, err := autotracer.NewTracerProvider(ctx, autotracer.WithWriter(io.Discard))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, stop(ctx)) }()
+
+		_, span := tracer.Tracer("test").Start(ctx, "test")
+		span.End()
+		forceFlush(t, ctx, tracer)
+
+		require.Equal(t, int64(1), requests.Load())
 	})
 	t.Run("Negative", func(t *testing.T) {
 		for _, exp := range []string{

--- a/autotracer/autotracer_test.go
+++ b/autotracer/autotracer_test.go
@@ -9,9 +9,21 @@ import (
 	"github.com/stretchr/testify/require"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/go-faster/sdk/autotracer"
 )
+
+// forceFlush exports pending spans, since [tracetest.InMemoryExporter] resets records on shutdown.
+func forceFlush(t *testing.T, ctx context.Context, provider trace.TracerProvider) {
+	t.Helper()
+
+	flusher, ok := provider.(interface {
+		ForceFlush(ctx context.Context) error
+	})
+	require.True(t, ok)
+	require.NoError(t, flusher.ForceFlush(ctx))
+}
 
 func TestNewTracerProvider(t *testing.T) {
 	ctx := context.Background()
@@ -54,6 +66,38 @@ func TestNewTracerProvider(t *testing.T) {
 			})
 		}
 	})
+	t.Run("Additional", func(t *testing.T) {
+		t.Setenv("OTEL_TRACES_EXPORTER", "stdout")
+
+		exp := tracetest.NewInMemoryExporter()
+		tracer, stop, err := autotracer.NewTracerProvider(ctx,
+			autotracer.WithWriter(io.Discard),
+			autotracer.WithAdditionalExporters(exp),
+		)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, stop(ctx)) }()
+
+		_, span := tracer.Tracer("test").Start(ctx, "test")
+		span.End()
+		forceFlush(t, ctx, tracer)
+
+		require.Len(t, exp.GetSpans(), 1)
+	})
+	t.Run("AdditionalNone", func(t *testing.T) {
+		t.Setenv("OTEL_TRACES_EXPORTER", "none")
+
+		exp := tracetest.NewInMemoryExporter()
+		tracer, stop, err := autotracer.NewTracerProvider(ctx,
+			autotracer.WithAdditionalExporters(exp),
+		)
+		require.NoError(t, err)
+
+		_, span := tracer.Tracer("test").Start(ctx, "test")
+		span.End()
+		require.NoError(t, stop(ctx))
+
+		require.Empty(t, exp.GetSpans())
+	})
 	t.Run("Multiple", func(t *testing.T) {
 		t.Setenv("OTEL_TRACES_EXPORTER", "first,second")
 
@@ -71,14 +115,11 @@ func TestNewTracerProvider(t *testing.T) {
 			}),
 		)
 		require.NoError(t, err)
+		defer func() { require.NoError(t, stop(ctx)) }()
 
 		_, span := tracer.Tracer("test").Start(ctx, "test")
 		span.End()
-		// InMemoryExporter resets records on shutdown.
-		require.NoError(t, tracer.(interface {
-			ForceFlush(ctx context.Context) error
-		}).ForceFlush(ctx))
-		defer func() { require.NoError(t, stop(ctx)) }()
+		forceFlush(t, ctx, tracer)
 
 		for name, exp := range exporters {
 			spans := exp.GetSpans()

--- a/autotracer/config.go
+++ b/autotracer/config.go
@@ -10,9 +10,10 @@ import (
 
 // config contains configuration options for a MeterProvider.
 type config struct {
-	res    *resource.Resource
-	writer io.Writer
-	lookup LookupExporter
+	res        *resource.Resource
+	writer     io.Writer
+	lookup     LookupExporter
+	additional []sdktrace.SpanExporter
 }
 
 // newConfig returns a config configured with options.
@@ -54,6 +55,17 @@ func WithResource(res *resource.Resource) Option {
 func WithWriter(out io.Writer) Option {
 	return optionFunc(func(conf config) config {
 		conf.writer = out
+		return conf
+	})
+}
+
+// WithAdditionalExporters adds exporters used in addition to the ones configured
+// by OTEL_TRACES_EXPORTER, e.g. to fan out spans to a second backend.
+//
+// Ignored if OTEL_TRACES_EXPORTER is set to "none".
+func WithAdditionalExporters(exporters ...sdktrace.SpanExporter) Option {
+	return optionFunc(func(conf config) config {
+		conf.additional = append(conf.additional, exporters...)
 		return conf
 	})
 }

--- a/internal/autoenv/exporters.go
+++ b/internal/autoenv/exporters.go
@@ -1,0 +1,34 @@
+// Package autoenv provides helpers for parsing OpenTelemetry environment variables.
+package autoenv
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/go-faster/errors"
+)
+
+// ExporterNone is a name of the no-op exporter.
+const ExporterNone = "none"
+
+// ParseExporters parses comma-separated exporter list, like OTEL_TRACES_EXPORTER.
+//
+// Empty entries are ignored, duplicates are removed. [ExporterNone] is only
+// valid as the only entry.
+func ParseExporters(v string) ([]string, error) {
+	var names []string
+	for name := range strings.SplitSeq(v, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" || slices.Contains(names, name) {
+			continue
+		}
+		names = append(names, name)
+	}
+	switch {
+	case len(names) == 0:
+		return nil, errors.New("no exporters")
+	case len(names) > 1 && slices.Contains(names, ExporterNone):
+		return nil, errors.Errorf("%q exporter can't be used with other exporters", ExporterNone)
+	}
+	return names, nil
+}

--- a/internal/autoenv/exporters.go
+++ b/internal/autoenv/exporters.go
@@ -2,6 +2,7 @@
 package autoenv
 
 import (
+	"os"
 	"slices"
 	"strings"
 
@@ -16,14 +17,7 @@ const ExporterNone = "none"
 // Empty entries are ignored, duplicates are removed. [ExporterNone] is only
 // valid as the only entry.
 func ParseExporters(v string) ([]string, error) {
-	var names []string
-	for name := range strings.SplitSeq(v, ",") {
-		name = strings.TrimSpace(name)
-		if name == "" || slices.Contains(names, name) {
-			continue
-		}
-		names = append(names, name)
-	}
+	names := parseList(v)
 	switch {
 	case len(names) == 0:
 		return nil, errors.New("no exporters")
@@ -31,4 +25,30 @@ func ParseExporters(v string) ([]string, error) {
 		return nil, errors.Errorf("%q exporter can't be used with other exporters", ExporterNone)
 	}
 	return names, nil
+}
+
+// AdditionalEndpoints returns additional OTLP endpoints for the given signal,
+// e.g. "TRACES", to fan out telemetry to more than one backend.
+//
+// Reads comma-separated GOFASTER_OTLP_<SIGNAL>_ENDPOINTS, falling back to
+// GOFASTER_OTLP_ENDPOINTS. These are not defined by the OpenTelemetry
+// specification, where OTEL_EXPORTER_OTLP_ENDPOINT is singular.
+func AdditionalEndpoints(signal string) []string {
+	v := os.Getenv("GOFASTER_OTLP_" + signal + "_ENDPOINTS")
+	if v == "" {
+		v = os.Getenv("GOFASTER_OTLP_ENDPOINTS")
+	}
+	return parseList(v)
+}
+
+func parseList(v string) []string {
+	var list []string
+	for e := range strings.SplitSeq(v, ",") {
+		e = strings.TrimSpace(e)
+		if e == "" || slices.Contains(list, e) {
+			continue
+		}
+		list = append(list, e)
+	}
+	return list
 }

--- a/internal/autoenv/exporters_test.go
+++ b/internal/autoenv/exporters_test.go
@@ -1,0 +1,38 @@
+package autoenv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseExporters(t *testing.T) {
+	tests := []struct {
+		value   string
+		want    []string
+		wantErr bool
+	}{
+		{"otlp", []string{"otlp"}, false},
+		{" otlp ", []string{"otlp"}, false},
+		{"otlp,console", []string{"otlp", "console"}, false},
+		{"otlp, console ,", []string{"otlp", "console"}, false},
+		{"otlp,otlp", []string{"otlp"}, false},
+		{"none", []string{"none"}, false},
+
+		{"", nil, true},
+		{",", nil, true},
+		{"none,otlp", nil, true},
+		{"otlp,none", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			got, err := ParseExporters(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/autoenv/exporters_test.go
+++ b/internal/autoenv/exporters_test.go
@@ -6,6 +6,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAdditionalEndpoints(t *testing.T) {
+	t.Run("Unset", func(t *testing.T) {
+		t.Setenv("GOFASTER_OTLP_ENDPOINTS", "")
+		t.Setenv("GOFASTER_OTLP_TRACES_ENDPOINTS", "")
+		require.Empty(t, AdditionalEndpoints("TRACES"))
+	})
+	t.Run("Common", func(t *testing.T) {
+		t.Setenv("GOFASTER_OTLP_ENDPOINTS", "http://a:4317, http://b:4317 ,,http://a:4317")
+		require.Equal(t, []string{"http://a:4317", "http://b:4317"}, AdditionalEndpoints("TRACES"))
+	})
+	t.Run("SignalOverride", func(t *testing.T) {
+		t.Setenv("GOFASTER_OTLP_ENDPOINTS", "http://a:4317")
+		t.Setenv("GOFASTER_OTLP_TRACES_ENDPOINTS", "http://b:4317")
+		require.Equal(t, []string{"http://b:4317"}, AdditionalEndpoints("TRACES"))
+		require.Equal(t, []string{"http://a:4317"}, AdditionalEndpoints("LOGS"))
+	})
+}
+
 func TestParseExporters(t *testing.T) {
 	tests := []struct {
 		value   string

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -25,8 +25,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-faster/sdk/internal/pool"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-faster/sdk/internal/pool"
 )
 
 type pooledValue[T any] struct {

--- a/internal/zapencoder/reflected_test.go
+++ b/internal/zapencoder/reflected_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-faster/sdk/gold"
-	"github.com/go-faster/sdk/internal/zapencoder"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/go-faster/sdk/gold"
+	"github.com/go-faster/sdk/internal/zapencoder"
 )
 
 func constantTimeEncoder(now time.Time) zapcore.TimeEncoder {


### PR DESCRIPTION
Fixes #299.

**1. Comma-separated exporter lists** (spec compliance)

`OTEL_{TRACES,METRICS,LOGS}_EXPORTER` is a comma-separated list per spec, so `otlp,console` now enables both exporters instead of failing startup. Parsing lives in `internal/autoenv`:

- empty entries are skipped, duplicates de-duplicated (`otlp,otlp` → one exporter);
- `none` is only valid as the sole entry, otherwise it is an error;
- each element resolves through the same switch, `cfg.lookup` still handles unknown names;
- `console` is accepted as a spec-name alias for `stdout`.

Provider construction is hoisted out of the per-exporter switch: `new{SpanExporter,LogExporter,MetricReader}` returns one exporter, the provider is built once from all of them.

**2. `WithAdditionalExporters`**

Programmatic fan-out for `autotracer`/`autologs`/`autometer`. Ignored when the signal is disabled with `none`, so the operator keeps the off switch.

**3. Broken exporter no longer kills the signal**

An exporter that fails to initialize is logged (`zap.Warn`) and skipped; an error is returned only when *none* could be set up. A single bad value still fails, as before.

**4. `GOFASTER_OTLP_ENDPOINTS` — the actual dual-write fix**

`OTEL_EXPORTER_OTLP_ENDPOINT` is singular, and a list of exporter *names* can't express two endpoints, so a second backend needed app code. Now:

```
OTEL_EXPORTER_OTLP_ENDPOINT=http://primary:4317
GOFASTER_OTLP_ENDPOINTS=http://shadow:4317,http://third:4317

# per-signal override
GOFASTER_OTLP_TRACES_ENDPOINTS=http://shadow:4317
```

Each entry becomes its own OTLP exporter using the standard protocol resolution (`OTEL_EXPORTER_OTLP_PROTOCOL` / per-signal), URL form via `WithEndpointURL`, bare `host:port` via `WithEndpoint`. Deliberately outside the `OTEL_` namespace since it is not in the spec. Skipped entirely when the signal is `none`.

Covered by tests that emit a span/metric/log and assert an `httptest` second endpoint actually received the export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)