### PR TITLE
ci: drop codeql job from pr workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,9 +24,3 @@ jobs:
     uses: go-faster/x/.github/workflows/commit.yml@main
     permissions:
       contents: read
-  codeql:
-    uses: go-faster/x/.github/workflows/codeql.yml@main
-    permissions:
-      actions: read
-      contents: read
-      security-events: write


### PR DESCRIPTION
The `codeql` job duplicates the repository's default CodeQL setup (which runs as a separate "CodeQL" check and passes) and fails on every PR with:

```
Code Scanning could not process the submitted SARIF file
```

Scanning is unaffected — the default setup keeps analyzing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)